### PR TITLE
chore: Update tauri dependency to version 2.0.0-rc.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/FabianLars/tauri-plugin-oauth"
 links = "tauri-plugin-oauth"
 
 [dependencies]
-tauri = { version = "2.0.0-beta.12" }
+tauri = { version = "2.0.0-rc.0" }
 httparse = "1"
 log = "0.4"
 serde = "1"
@@ -20,4 +20,4 @@ url = "2"
 thiserror = "1.0"
 
 [build-dependencies]
-tauri-plugin = { version = "2.0.0-beta.10", features = ["build"] }
+tauri-plugin = { version = "2.0.0-rc.0", features = ["build"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub fn cancel(port: u16) -> Result<(), std::io::Error> {
 }
 
 mod plugin_impl {
-    use tauri::{Manager, Runtime, Window};
+    use tauri::{Emitter, Manager, Runtime, Window};
 
     #[tauri::command]
     pub(crate) fn start<R: Runtime>(


### PR DESCRIPTION
Hello! Today I was working on a Tauri application with version V2 RC and I thought about using this plugin since my application requires OAuth. Unfortunately, when compiling the project it fails because it indicates that it cannot find `window.emit`, as shown in the photo. Therefore, I decided to update this plugin to the latest version of Tauri. 

I don't usually make pull requests or contributions, so please let me know if I made any mistakes. I hope this small correction helps in some way.

![image](https://github.com/user-attachments/assets/74123754-525f-4818-9fd9-e480710bc0c8)
